### PR TITLE
Add alias for the Guard contract to auth.driver

### DIFF
--- a/src/AuthServiceProvider.php
+++ b/src/AuthServiceProvider.php
@@ -48,5 +48,7 @@ class AuthServiceProvider extends LaravelAuth
 		$this->app->singleton('auth.driver', function ($app) {
 			return $app['auth']->driver();
 		});
+		
+		$this->app->alias('auth.driver', 'MyBB\Auth\Contracts\Guard');
 	}
 }


### PR DESCRIPTION
@euantorano @JN-Jones when I created a new controller, I got a "Mybb\Auth\Contracts\Guard is not instantiable" exception from the container when it was trying to resolve `MyBB\Core\Http\Controllers\Controller`, this fixed it.

Did either of you have a similar problem at any stage? I can't really see how it ever would have worked?
